### PR TITLE
Correcting package name. Packagist doesn't like uppercase characters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "JamesHeinrich/phpThumb",
+    "name": "jamesheinrich/phpthumb",
     "description": "The PHP thumbnail generator",
     "type": "library",
     "license": "GPL",


### PR DESCRIPTION
Just attempted to add the package and it seems Packagist doesn't like uppercase characters so I've altered this.
