### PR TITLE
Fix filename for downloaded images

### DIFF
--- a/phpThumb.php
+++ b/phpThumb.php
@@ -29,7 +29,7 @@ function SendSaveAsFileHeaderIfNeeded() {
 		return false;
 	}
 	global $phpThumb;
-	$downloadfilename = phpthumb_functions::SanitizeFilename(!empty($_GET['sia']) ? $_GET['sia'] : (!empty($_GET['down']) ? $_GET['down'] : 'phpThumb_generated_thumbnail'.(!empty($_GET['f']) ? $_GET['f'] : 'jpg')));
+	$downloadfilename = phpthumb_functions::SanitizeFilename(!empty($_GET['sia']) ? $_GET['sia'] : (!empty($_GET['down']) ? $_GET['down'] : 'phpThumb_generated_thumbnail.'.(!empty($_GET['f']) ? $_GET['f'] : 'jpg')));
 	if (!empty($downloadfilename)) {
 		$phpThumb->DebugMessage('SendSaveAsFileHeaderIfNeeded() sending header: Content-Disposition: '.(!empty($_GET['down']) ? 'attachment' : 'inline').'; filename="'.$downloadfilename.'"', __FILE__, __LINE__);
 		header('Content-Disposition: '.(!empty($_GET['down']) ? 'attachment' : 'inline').'; filename="'.$downloadfilename.'"');


### PR DESCRIPTION
Filename is missing a period for the default download filename:
```'phpThumb_generated_thumbnail'.(!empty($_GET['f']) ? $_GET['f'] : 'jpg')```
> phpThumb_generated_thumbnailjpg

Fixed:
```'phpThumb_generated_thumbnail.'.(!empty($_GET['f']) ? $_GET['f'] : 'jpg')```
> phpThumb_generated_thumbnail.jpg