### PR TITLE
Fixed incorrect use of Last-Modified header

### DIFF
--- a/phpThumb.php
+++ b/phpThumb.php
@@ -86,7 +86,8 @@ function RedirectToCachedFile() {
 		header('Pragma: private');
 		header('Expires: '.date(DATE_RFC822, strtotime(' 1 day')));
 		if (!empty($_SERVER['HTTP_IF_MODIFIED_SINCE']) && ($nModified == strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE'])) && !empty($_SERVER['SERVER_PROTOCOL'])) {
-			header('Last-Modified: '.gmdate('D, d M Y H:i:s', $nModified).' GMT', true, 304);
+			header('Last-Modified: '.gmdate('D, d M Y H:i:s', $nModified).' GMT');
+			header($_SERVER['SERVER_PROTOCOL'].' 304 Not Modified');
 			exit;
 		}
 		if ($getimagesize = @GetImageSize($phpThumb->cache_filename)) {


### PR DESCRIPTION
Last-Modified header should contain only the HTTP date, as defined by RFC 2616 http://tools.ietf.org/html/rfc2616#section-14.29

To maintain functionality, added 304 Not Modified header using dynamic SERVER_PROTOCOL