### PR TITLE
Fixed a problem in SafeURLread()

### DIFF
--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -784,6 +784,8 @@ class phpthumb_functions {
 			curl_setopt($ch, CURLOPT_HEADER, false);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_BINARYTRANSFER, true);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 			curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 			$rawData = curl_exec($ch);
 			curl_close($ch);


### PR DESCRIPTION
Fixed a problem related to URL (https) with an invalid SSL certificate (as with MAMP for example)