### PR TITLE
added initializations of variables, removed superfluous variables et al

### DIFF
--- a/phpThumb.php
+++ b/phpThumb.php
@@ -111,7 +111,7 @@ if (!include_once(dirname(__FILE__).'/phpthumb.class.php')) {
 ob_end_clean();
 $phpThumb = new phpThumb();
 $phpThumb->DebugTimingMessage('phpThumb.php start', __FILE__, __LINE__, $starttime);
-$phpThumb->SetParameter('config_error_die_on_error', true);
+$phpThumb->setParameter('config_error_die_on_error', true);
 
 if (!phpthumb_functions::FunctionIsDisabled('set_time_limit')) {
 	set_time_limit(60);  // shouldn't take nearly this long in most cases, but with many filters and/or a slow server...
@@ -229,9 +229,10 @@ if (empty($_SERVER['PATH_INFO']) && empty($_SERVER['QUERY_STRING'])) {
 }
 
 if (!empty($_GET['src']) && isset($_GET['md5s']) && empty($_GET['md5s'])) {
+	$md5s = '';
 	if (preg_match('#^([a-z0-9]+)://#i', $_GET['src'], $protocol_matches)) {
 		if (preg_match('#^(f|ht)tps?://#i', $_GET['src'])) {
-			if ($rawImageData = phpthumb_functions::SafeURLread($_GET['src'], $error, $phpThumb->config_http_fopen_timeout, $phpThumb->config_http_follow_redirect)) {
+			if ($rawImageData = phpthumb_functions::SafeURLread($_GET['src'], $error, $phpThumb->config_http_fopen_timeout)) {
 				$md5s = md5($rawImageData);
 			}
 		} else {
@@ -509,6 +510,7 @@ while ($CanPassThroughDirectly && $phpThumb->src) {
 
 		$ImageCreateFunctions = array(1=>'imagecreatefromgif', 2=>'imagecreatefromjpeg', 3=>'imagecreatefrompng');
 		$theImageCreateFunction = @$ImageCreateFunctions[$phpThumb->getimagesizeinfo[2]];
+		$dummyImage = false;
 		if ($phpThumb->config_disable_onlycreateable_passthru || (function_exists($theImageCreateFunction) && ($dummyImage = @$theImageCreateFunction($SourceFilename)))) {
 
 			// great
@@ -614,7 +616,7 @@ if ($phpThumb->rawImageData) {
 		$phpThumb->DebugMessage('CleanUpURLencoding('.$phpThumb->src.') returned "'.$cleanedupurl.'"', __FILE__, __LINE__);
 		$phpThumb->src = $cleanedupurl;
 		unset($cleanedupurl);
-		if ($rawImageData = phpthumb_functions::SafeURLread($phpThumb->src, $error, $phpThumb->config_http_fopen_timeout, $phpThumb->config_http_follow_redirect)) {
+		if ($rawImageData = phpthumb_functions::SafeURLread($phpThumb->src, $error, $phpThumb->config_http_fopen_timeout)) {
 			$phpThumb->DebugMessage('SafeURLread('.$phpThumb->src.') succeeded'.($error ? ' with messsages: "'.$error.'"' : ''), __FILE__, __LINE__);
 			$phpThumb->DebugMessage('Setting source data from URL "'.$phpThumb->src.'"', __FILE__, __LINE__);
 			$phpThumb->setSourceData($rawImageData, urlencode($phpThumb->src));

--- a/phpthumb.bmp.php
+++ b/phpthumb.bmp.php
@@ -20,10 +20,6 @@
 
 class phpthumb_bmp {
 
-	function phpthumb_bmp() {
-		return true;
-	}
-
 	function phpthumb_bmp2gd(&$BMPdata, $truecolor=true) {
 		$ThisFileInfo = array();
 		if ($this->getid3_bmp($BMPdata, $ThisFileInfo, true, true)) {
@@ -227,7 +223,6 @@ class phpthumb_bmp {
 				$thisfile_bmp_header_raw['color_encoding']   = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 				$offset += 4;
 				$thisfile_bmp_header_raw['identifier']       = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
-				$offset += 4;
 
 				$thisfile_bmp_header['compression']          = $this->BMPcompressionOS2Lookup($thisfile_bmp_header_raw['compression']);
 
@@ -252,9 +247,9 @@ class phpthumb_bmp {
 			// DWORD  biClrUsed;
 			// DWORD  biClrImportant;
 
-			$thisfile_bmp_header_raw['width']            = $this->LittleEndian2Int(substr($BMPheader, $offset, 4), true);
+			$thisfile_bmp_header_raw['width']            = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
-			$thisfile_bmp_header_raw['height']           = $this->LittleEndian2Int(substr($BMPheader, $offset, 4), true);
+			$thisfile_bmp_header_raw['height']           = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
 			$thisfile_bmp_header_raw['planes']           = $this->LittleEndian2Int(substr($BMPheader, $offset, 2));
 			$offset += 2;
@@ -264,9 +259,9 @@ class phpthumb_bmp {
 			$offset += 4;
 			$thisfile_bmp_header_raw['bmp_data_size']    = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
-			$thisfile_bmp_header_raw['resolution_h']     = $this->LittleEndian2Int(substr($BMPheader, $offset, 4), true);
+			$thisfile_bmp_header_raw['resolution_h']     = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
-			$thisfile_bmp_header_raw['resolution_v']     = $this->LittleEndian2Int(substr($BMPheader, $offset, 4), true);
+			$thisfile_bmp_header_raw['resolution_v']     = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
 			$thisfile_bmp_header_raw['colors_used']      = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
@@ -340,7 +335,6 @@ class phpthumb_bmp {
 				$thisfile_bmp_header_raw['profile_data_size']   = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 				$offset += 4;
 				$thisfile_bmp_header_raw['reserved3']           = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
-				$offset += 4;
 			}
 
 		} else {
@@ -359,7 +353,6 @@ class phpthumb_bmp {
 			}
 			if ($PaletteEntries > 0) {
 				$BMPpalette = substr($BMPdata, $overalloffset, 4 * $PaletteEntries);
-				$overalloffset += 4 * $PaletteEntries;
 
 				$paletteoffset = 0;
 				for ($i = 0; $i < $PaletteEntries; $i++) {
@@ -385,7 +378,6 @@ class phpthumb_bmp {
 			$RowByteLength = ceil(($thisfile_bmp_header_raw['width'] * ($thisfile_bmp_header_raw['bits_per_pixel'] / 8)) / 4) * 4; // round up to nearest DWORD boundry
 
 			$BMPpixelData = substr($BMPdata, $thisfile_bmp_header_raw['data_offset'], $thisfile_bmp_header_raw['height'] * $RowByteLength);
-			$overalloffset = $thisfile_bmp_header_raw['data_offset'] + ($thisfile_bmp_header_raw['height'] * $RowByteLength);
 
 			$pixeldataoffset = 0;
 			switch (@$thisfile_bmp_header_raw['compression']) {
@@ -592,6 +584,7 @@ class phpthumb_bmp {
 											// high- and low-order 4 bits, one color index for each pixel. In absolute mode,
 											// each run must be aligned on a word boundary.
 											unset($paletteindexes);
+											$paletteindexes = [];
 											for ($i = 0; $i < ceil($secondbyte / 2); $i++) {
 												$paletteindexbyte = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
 												$paletteindexes[] = ($paletteindexbyte & 0xF0) >> 4;

--- a/phpthumb.bmp.php
+++ b/phpthumb.bmp.php
@@ -757,13 +757,11 @@ class phpthumb_bmp {
 			echo 'plotted '.($BMPinfo['resolution_x'] * $BMPinfo['resolution_y']).' pixels in '.(time() - $starttime).' seconds<BR>';
 			imagedestroy($im);
 			exit;
-		} else {
-			header('Content-Type: image/png');
-			imagepng($im);
-			imagedestroy($im);
-			return true;
 		}
-		return false;
+		header('Content-Type: image/png');
+        imagepng($im);
+        imagedestroy($im);
+        return true;
 	}
 
 	function BMPcompressionWindowsLookup($compressionid) {

--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -533,7 +533,6 @@ class phpthumb {
 				break;
 
 			case 'bmp':
-				$ImageOutFunction = '"builtin BMP output"';
 				if (!@include_once(dirname(__FILE__).'/phpthumb.bmp.php')) {
 					$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.bmp.php" which is required for BMP format output', __FILE__, __LINE__);
 					ob_end_clean();
@@ -545,7 +544,6 @@ class phpthumb {
 				break;
 
 			case 'ico':
-				$ImageOutFunction = '"builtin ICO output"';
 				if (!@include_once(dirname(__FILE__).'/phpthumb.ico.php')) {
 					$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.ico.php" which is required for ICO format output', __FILE__, __LINE__);
 					ob_end_clean();

--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -635,7 +635,7 @@ class phpthumb {
 		} else {
 
 			$this->DebugMessage('ImageInterlace($this->gdimg_output, '.intval($this->config_output_interlace).')', __FILE__, __LINE__);
-			ImageInterlace($this->gdimg_output, intval($this->config_output_interlace));
+			imageinterlace($this->gdimg_output, intval($this->config_output_interlace));
 			switch ($this->thumbnailFormat) {
 				case 'jpeg':
 					header('Content-Type: '.phpthumb_functions::ImageTypeToMIMEtype($this->thumbnailFormat));

--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -3314,7 +3314,7 @@ if (false) {
 		$this->DebugMessage('starting ExtractEXIFgetImageSize()', __FILE__, __LINE__);
 
 		if (preg_match('#^http:#i', $this->src) && !$this->sourceFilename && $this->rawImageData) {
-			!$this->SourceDataToTempFile();
+			$this->SourceDataToTempFile();
 		}
 		if (is_null($this->getimagesizeinfo)) {
 			if ($this->sourceFilename) {

--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -2750,7 +2750,6 @@ if (false) {
 						$alignment = ($alignment ? $alignment : 'BR');
 						$opacity   = ($opacity   ? $opacity   :   50);
 						$margin_x  = ($margin_x  ? $margin_x  :    5);
-						$margin_y  = $margin_y; // just to note it wasn't forgotten, but let the value always pass unchanged
 						$phpthumbFilters->HistogramOverlay($this->gdimg_output, $bands, $colors, $width, $height, $alignment, $opacity, $margin_x, $margin_y);
 						break;
 

--- a/phpthumb.filters.php
+++ b/phpthumb.filters.php
@@ -13,10 +13,6 @@ class phpthumb_filters {
 
 	var $phpThumbObject = null;
 
-	function phpthumb_filters() {
-		return true;
-	}
-
 	function DebugMessage($message, $file='', $line='') {
 		if (is_object($this->phpThumbObject)) {
 			return $this->phpThumbObject->DebugMessage($message, $file, $line);
@@ -96,7 +92,7 @@ class phpthumb_filters {
 
 
 	public function Blur(&$gdimg, $radius=0.5) {
-		// Taken from Torstein Hønsi's phpUnsharpMask (see phpthumb.unsharp.php)
+		// Taken from Torstein Hï¿½nsi's phpUnsharpMask (see phpthumb.unsharp.php)
 
 		$radius = round(max(0, min($radius, 50)) * 2);
 		if (!$radius) {
@@ -177,6 +173,7 @@ class phpthumb_filters {
 		for ($x = 0; $x < imagesx($gdimg); $x++) {
 			for ($y = 0; $y < imagesy($gdimg); $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
+				$NewPixel = [];
 				foreach ($OriginalPixel as $key => $value) {
 					$NewPixel[$key] = round($baseamount + ($OriginalPixel[$key] * $scaling));
 				}
@@ -212,6 +209,7 @@ class phpthumb_filters {
 		for ($x = 0; $x < imagesx($gdimg); $x++) {
 			for ($y = 0; $y < imagesy($gdimg); $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
+				$NewPixel = [];
 				foreach ($OriginalPixel as $key => $value) {
 					$NewPixel[$key] = min(255, max(0, round($OriginalPixel[$key] * $scaling)));
 				}
@@ -245,6 +243,7 @@ class phpthumb_filters {
 			// fall through and try it the hard way
 		}
 
+		$TargetPixel = [];
 		// overridden below for grayscale
 		if ($targetColor != 'gray') {
 			$TargetPixel['red']   = hexdec(substr($targetColor, 0, 2));
@@ -258,6 +257,7 @@ class phpthumb_filters {
 				if ($targetColor == 'gray') {
 					$TargetPixel = phpthumb_functions::GrayscalePixel($OriginalPixel);
 				}
+				$NewPixel = [];
 				foreach ($TargetPixel as $key => $value) {
 					$NewPixel[$key] = round(max(0, min(255, ($OriginalPixel[$key] * ((100 - $amount) / 100)) + ($TargetPixel[$key] * $amountPct))));
 				}
@@ -325,10 +325,7 @@ class phpthumb_filters {
 			return true;
 		}
 
-		$width_shadow  = cos(deg2rad($angle)) * ($distance + $width);
-		$height_shadow = sin(deg2rad($angle)) * ($distance + $width);
-
-		$scaling = min(imagesx($gdimg) / (imagesx($gdimg) + abs($width_shadow)), imagesy($gdimg) / (imagesy($gdimg) + abs($height_shadow)));
+		$Offset= [];
 
 		for ($i = 0; $i < $width; $i++) {
 			$WidthAlpha[$i] = (abs(($width / 2) - $i) / $width);
@@ -340,7 +337,7 @@ class phpthumb_filters {
 		$tempImageHeight = imagesy($gdimg) + abs($Offset['y']);
 
 		if ($gdimg_dropshadow_temp = phpthumb_functions::ImageCreateFunction($tempImageWidth, $tempImageHeight)) {
-
+			$PixelMap = [];
 			imagealphablending($gdimg_dropshadow_temp, false);
 			imagesavealpha($gdimg_dropshadow_temp, true);
 			$transparent1 = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg_dropshadow_temp, 0, 0, 0, 127);
@@ -521,6 +518,7 @@ class phpthumb_filters {
 	public function HistogramAnalysis(&$gdimg, $calculateGray=false) {
 		$ImageSX = imagesx($gdimg);
 		$ImageSY = imagesy($gdimg);
+        $Analysis = [];
 		for ($x = 0; $x < $ImageSX; $x++) {
 			for ($y = 0; $y < $ImageSY; $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
@@ -563,7 +561,8 @@ class phpthumb_filters {
 		// pixels to be clipped to min/max
 		$threshold = floatval($threshold) / 100;
 		$clip_threshold = imagesx($gdimg) * imagesx($gdimg) * $threshold;
-		//if ($min >= 0) {
+		$range_min = 0;
+        //if ($min >= 0) {
 		//	$range_min = min($min, 255);
 		//} else {
 			$countsum = 0;
@@ -579,6 +578,7 @@ class phpthumb_filters {
 				}
 			}
 			$range_min = max($range_min, 0);
+			$range_max = 255;
 		//}
 		//if ($max > 0) {
 		//	$range_max = max($max, 255);
@@ -686,7 +686,6 @@ class phpthumb_filters {
 
 		list($new_width, $new_height) = phpthumb_functions::ProportionalResize($output_width, $output_height, $output_width - max($border_width * 2, $radius_x), $output_height - max($border_width * 2, $radius_y));
 		$offset_x = ($radius_x ? $output_width  - $new_width  - $radius_x : 0);
-		$offset_y = ($radius_y ? $output_height - $new_height - $radius_y : 0);
 
 		if ($gd_border_canvas = phpthumb_functions::ImageCreateFunction($output_width, $output_height)) {
 
@@ -763,6 +762,7 @@ class phpthumb_filters {
 				//$this->DebugMessage('Using alpha rotate', __FILE__, __LINE__);
 				if ($gdimg_rotate_mask = phpthumb_functions::ImageCreateFunction(imagesx($gdimg_source), imagesy($gdimg_source))) {
 
+					$color_mask = [];
 					for ($i = 0; $i <= 255; $i++) {
 						$color_mask[$i] = imagecolorallocate($gdimg_rotate_mask, $i, $i, $i);
 					}
@@ -970,7 +970,7 @@ class phpthumb_filters {
 				// "In the traditional sepia toning process, the tinting occurs most in
 				// the mid-tones: the lighter and darker areas appear to be closer to B&W."
 				$SepiaAmount = ((128 - abs($GrayPixel['red'] - 128)) / 128) * $amountPct;
-
+				$NewPixel = [];
 				foreach ($TargetPixel as $key => $value) {
 					$NewPixel[$key] = round(max(0, min(255, $GrayPixel[$key] * (1 - $SepiaAmount) + ($TargetPixel[$key] * $SepiaAmount))));
 				}
@@ -1177,7 +1177,8 @@ class phpthumb_filters {
 			} else {
 
 				// this block for background color only
-
+				$text_origin_x = 0;
+				$text_origin_y = 0;
 				switch ($alignment) {
 					case '*':
 						// handled separately
@@ -1262,13 +1263,7 @@ class phpthumb_filters {
 					$TTFboxLine = imagettfbbox($size, $angle, $ttffont, $line);
 					$min_x_line = min($TTFboxLine[0], $TTFboxLine[2], $TTFboxLine[4], $TTFboxLine[6]);
 					$max_x_line = max($TTFboxLine[0], $TTFboxLine[2], $TTFboxLine[4], $TTFboxLine[6]);
-					//$text_width = round($max_x - $min_x + ($size * 0.5));
 					$text_width_line = round($max_x_line - $min_x_line);
-
-					$min_y_line = min($TTFboxLine[1], $TTFboxLine[3], $TTFboxLine[5], $TTFboxLine[7]);
-					$max_y_line = max($TTFboxLine[1], $TTFboxLine[3], $TTFboxLine[5], $TTFboxLine[7]);
-					//$text_height = round($max_y - $min_y + ($size * 0.5));
-					$text_height_line = round($max_y_line - $min_y_line);
 
 					switch ($alignment) {
 						// $text_origin_y set above, just re-set $text_origin_x here as needed
@@ -1324,6 +1319,7 @@ class phpthumb_filters {
 				$this->DebugMessage('WatermarkText() calling imagefilledrectangle($img_watermark, 0, 0, '.imagesx($img_watermark).', '.imagesy($img_watermark).', $text_color_background)', __FILE__, __LINE__);
 				imagefilledrectangle($img_watermark, 0, 0, imagesx($img_watermark), imagesy($img_watermark), $text_color_background);
 
+              $img_watermark_mask = $mask_color_background = $mask_color_watermark = false;
 				if ($angle && function_exists('imagerotate')) {
 					// using $img_watermark_mask is pointless if imagerotate function isn't available
 					if ($img_watermark_mask = phpthumb_functions::ImageCreateFunction($text_width, $text_height)) {
@@ -1335,6 +1331,7 @@ class phpthumb_filters {
 				}
 
 				$text_color_watermark = phpthumb_functions::ImageHexColorAllocate($img_watermark, $hex_color);
+                $x_offset = 0;
 				foreach ($textlines as $key => $line) {
 					switch ($alignment) {
 						case 'C':
@@ -1423,8 +1420,6 @@ class phpthumb_filters {
 	public function WatermarkOverlay(&$gdimg_dest, &$img_watermark, $alignment='*', $opacity=50, $margin_x=5, $margin_y=null) {
 
 		if (is_resource($gdimg_dest) && is_resource($img_watermark)) {
-			$watermark_source_x        = 0;
-			$watermark_source_y        = 0;
 			$img_source_width          = imagesx($gdimg_dest);
 			$img_source_height         = imagesy($gdimg_dest);
 			$watermark_source_width    = imagesx($img_watermark);
@@ -1433,6 +1428,8 @@ class phpthumb_filters {
 			$margin_y = (is_null($margin_y) ? $margin_x : $margin_y);
 			$watermark_margin_x = ((($margin_x > 0) && ($margin_x < 1)) ? round((1 - $margin_x) * $img_source_width)  : $margin_x);
 			$watermark_margin_y = ((($margin_y > 0) && ($margin_y < 1)) ? round((1 - $margin_y) * $img_source_height) : $margin_y);
+			$watermark_destination_x = 0;
+			$watermark_destination_y = 0;
 			if (preg_match('#^([0-9\\.\\-]*)x([0-9\\.\\-]*)$#i', $alignment, $matches)) {
 				$watermark_destination_x = intval($matches[1]);
 				$watermark_destination_y = intval($matches[2]);

--- a/phpthumb.filters.php
+++ b/phpthumb.filters.php
@@ -11,6 +11,9 @@
 
 class phpthumb_filters {
 
+    /**
+     * @var phpthumb
+     */
 	var $phpThumbObject = null;
 
 	function DebugMessage($message, $file='', $line='') {

--- a/phpthumb.filters.php
+++ b/phpthumb.filters.php
@@ -187,7 +187,7 @@ class phpthumb_filters {
 
 	public function Contrast(&$gdimg, $amount=0) {
 		if ($amount == 0) {
-			return true;
+			return;
 		}
 		$amount = max(-255, min(255, $amount));
 
@@ -195,7 +195,7 @@ class phpthumb_filters {
 			// imagefilter(IMG_FILTER_CONTRAST) has range +100 to -100 (positive numbers make it darker!)
 			$amount = ($amount / 255) * -100;
 			if (imagefilter($gdimg, IMG_FILTER_CONTRAST, $amount)) {
-				return true;
+				return;
 			}
 			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_CONTRAST, '.$amount.')', __FILE__, __LINE__);
 			// fall through and try it the hard way

--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -366,7 +366,7 @@ class phpthumb_functions {
 
 
 	static function ImageCreateFunction($x_size, $y_size) {
-		$ImageCreateFunction = 'ImageCreate';
+		$ImageCreateFunction = 'imagecreate';
 		if (phpthumb_functions::gd_version() >= 2.0) {
 			$ImageCreateFunction = 'imagecreatetruecolor';
 		}
@@ -472,7 +472,7 @@ class phpthumb_functions {
 
 				case 'exec':
 					$output = array();
-					$lastline = $execfunction($command, $output);
+					$execfunction($command, $output);
 					$returnvalue = implode("\n", $output);
 					break;
 
@@ -659,7 +659,7 @@ class phpthumb_functions {
 					$Data_body .= $line;
 				}
 				if (preg_match('#^HTTP/[\\.0-9]+ ([0-9]+) (.+)$#i', rtrim($line), $matches)) {
-					list($dummy, $errno, $errstr) = $matches;
+					list(, $errno, $errstr) = $matches;
 					$errno = intval($errno);
 				} elseif (preg_match('#^Location: (.*)$#i', rtrim($line), $matches)) {
 					$header_newlocation = $matches[1];
@@ -743,8 +743,10 @@ class phpthumb_functions {
 		return $parsedURL;
 	}
 
-	static function SafeURLread($url, &$error, $timeout=10, $followredirects=true) {
+	static function SafeURLread($url, &$error, $timeout=10) {
 		$error = '';
+        $errstr = '';
+        $rawData = '';
 
 		$parsed_url = phpthumb_functions::ParseURLbetter($url);
 		$alreadyLookedAtURLs[trim($url)] = true;
@@ -838,7 +840,6 @@ class phpthumb_functions {
 				break;
 			}
 		}
-		$i = $startoffset;
 		$endoffset = count($directory_elements);
 		for ($i = $startoffset; $i <= $endoffset; $i++) {
 			$test_directory = implode(DIRECTORY_SEPARATOR, array_slice($directory_elements, 0, $i));

--- a/phpthumb.gif.php
+++ b/phpthumb.gif.php
@@ -483,6 +483,9 @@ class CGIFFILEHEADER
 	var $m_nTableSize;
 	var $m_nBgColor;
 	var $m_nPixelRatio;
+    /**
+     * @var CGIFCOLORTABLE
+     */
 	var $m_colorTable;
 
 	///////////////////////////////////////////////////////////////////////////
@@ -559,6 +562,9 @@ class CGIFIMAGEHEADER
 	var $m_bInterlace;
 	var $m_bSorted;
 	var $m_nTableSize;
+    /**
+     * @var CGIFCOLORTABLE
+     */
 	var $m_colorTable;
 
 	///////////////////////////////////////////////////////////////////////////

--- a/phpthumb.gif.php
+++ b/phpthumb.gif.php
@@ -66,7 +66,7 @@ function gif_loadFileToGDimageResource($gifFilename, $bgColor = -1)
 
 function gif_outputAsBmp($gif, $lpszFileName, $bgColor = -1)
 {
-	if (!isSet($gif) || (@get_class($gif) <> 'cgif') || !$gif->loaded() || ($lpszFileName == '')) {
+	if (!isset($gif) || (@get_class($gif) <> 'cgif') || !$gif->loaded() || ($lpszFileName == '')) {
 		return false;
 	}
 
@@ -115,14 +115,14 @@ function gif_outputAsJpeg($gif, $lpszFileName, $bgColor = -1)
 
 		if (gif_outputAsBmp($gif, $lpszFileName.'.bmp', $bgColor)) {
 			exec('cjpeg '.$lpszFileName.'.bmp >'.$lpszFileName.' 2>/dev/null');
-			@unLink($lpszFileName.'.bmp');
+			@unlink($lpszFileName.'.bmp');
 
 			if (@file_exists($lpszFileName)) {
-				if (@fileSize($lpszFileName) > 0) {
+				if (@filesize($lpszFileName) > 0) {
 					return true;
 				}
 
-				@unLink($lpszFileName);
+				@unlink($lpszFileName);
 			}
 		}
 
@@ -170,7 +170,7 @@ class CGIFLZW
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIFLZW()
+	function __construct()
 	{
 		$this->MAX_LZW_BITS = 12;
 		unSet($this->Next);
@@ -384,7 +384,7 @@ class CGIFCOLORTABLE
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIFCOLORTABLE()
+	function __construct()
 	{
 		unSet($this->m_nColors);
 		unSet($this->m_arColors);
@@ -452,6 +452,7 @@ class CGIFCOLORTABLE
 		$g1   = ($rgb & 0x00FF00) >>  8;
 		$b1   = ($rgb & 0xFF0000) >> 16;
 		$idx  = -1;
+		$dif = 0;
 
 		for ($i = 0; $i < $this->m_nColors; $i++) {
 			$r2 = ($this->m_arColors[$i] & 0x000000FF);
@@ -487,7 +488,7 @@ class CGIFFILEHEADER
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIFFILEHEADER()
+	function __construct()
 	{
 		unSet($this->m_lpVer);
 		unSet($this->m_nWidth);
@@ -563,7 +564,7 @@ class CGIFIMAGEHEADER
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIFIMAGEHEADER()
+	function __construct()
 	{
 		unSet($this->m_nLeft);
 		unSet($this->m_nTop);
@@ -633,7 +634,7 @@ class CGIFIMAGE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function CGIFIMAGE()
+	function __construct()
 	{
 		unSet($this->m_disp);
 		unSet($this->m_bUser);
@@ -677,7 +678,6 @@ class CGIFIMAGE
 				if (!($this->m_data = $this->m_lzw->deCompress($data, $len = 0))) {
 					return false;
 				}
-				$data = substr($data, $len);
 				$datLen += $len;
 
 				if ($this->m_gih->m_bInterlace) {
@@ -751,6 +751,7 @@ class CGIFIMAGE
 	{
 		$data = $this->m_data;
 
+		$y = $s = 0;
 		for ($i = 0; $i < 4; $i++) {
 			switch($i) {
 			case 0:
@@ -801,7 +802,7 @@ class CGIF
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function CGIF()
+	function __construct()
 	{
 		$this->m_gfh     = new CGIFFILEHEADER();
 		$this->m_img     = new CGIFIMAGE();
@@ -821,7 +822,7 @@ class CGIF
 		if (!($fh = @fopen($lpszFileName, 'rb'))) {
 			return false;
 		}
-		$this->m_lpData = @fRead($fh, @fileSize($lpszFileName));
+		$this->m_lpData = @fread($fh, @filesize($lpszFileName));
 		fclose($fh);
 
 		// GET FILE HEADER
@@ -849,7 +850,7 @@ class CGIF
 		if (!($fh = @fopen($lpszFileName, 'rb'))) {
 			return false;
 		}
-		$data = @fRead($fh, @fileSize($lpszFileName));
+		$data = @fread($fh, @filesize($lpszFileName));
 		@fclose($fh);
 
 		$gfh = new CGIFFILEHEADER();
@@ -872,6 +873,7 @@ class CGIF
 			return false;
 		}
 
+		$rgbq = '';
 		// PREPARE COLOR TABLE (RGBQUADs)
 		if ($this->m_img->m_gih->m_bLocalClr) {
 			$nColors = $this->m_img->m_gih->m_nTableSize;
@@ -971,6 +973,7 @@ class CGIF
 			return false;
 		}
 
+		$pal = '';
 		// PREPARE COLOR TABLE (RGBQUADs)
 		if ($this->m_img->m_gih->m_bLocalClr) {
 			$nColors = $this->m_img->m_gih->m_nTableSize;
@@ -1084,6 +1087,7 @@ class CGIF
 
 		$PlottingIMG = imagecreate($this->m_gfh->m_nWidth, $this->m_gfh->m_nHeight);
 		$NumColorsInPal = floor(strlen($pal) / 3);
+        $ThisImageColor = [];
 		for ($i = 0; $i < $NumColorsInPal; $i++) {
 			$ThisImageColor[$i] = imagecolorallocate(
 									$PlottingIMG,

--- a/phpthumb.ico.php
+++ b/phpthumb.ico.php
@@ -12,13 +12,16 @@
 
 class phpthumb_ico {
 
-	function phpthumb_ico() {
-		return true;
-	}
-
-
 	function GD2ICOstring(&$gd_image_array) {
-		foreach ($gd_image_array as $key => $gd_image) {
+        $ImageWidths = [];
+        $ImageHeights = [];
+        $bpp = [];
+        $totalcolors = [];
+        $icXOR = [];
+        $icAND = [];
+        $icANDmask = [];
+
+        foreach ($gd_image_array as $key => $gd_image) {
 
 			$ImageWidths[$key]  = imagesx($gd_image);
 			$ImageHeights[$key] = imagesy($gd_image);
@@ -60,6 +63,7 @@ class phpthumb_ico {
 
 		}
 
+	    $BitmapInfoHeader = [];
 	    foreach ($gd_image_array as $key => $gd_image) {
 			$biSizeImage = $ImageWidths[$key] * $ImageHeights[$key] * ($bpp[$key] / 8);
 

--- a/phpthumb.ico.php
+++ b/phpthumb.ico.php
@@ -13,20 +13,20 @@
 class phpthumb_ico {
 
 	function GD2ICOstring(&$gd_image_array) {
-        $ImageWidths = [];
-        $ImageHeights = [];
-        $bpp = [];
-        $totalcolors = [];
-        $icXOR = [];
-        $icAND = [];
-        $icANDmask = [];
+		$ImageWidths = [];
+		$ImageHeights = [];
+		$bpp = [];
+		$totalcolors = [];
+		$icXOR = [];
+		$icAND = [];
+		$icANDmask = [];
 
-        foreach ($gd_image_array as $key => $gd_image) {
+		foreach ($gd_image_array as $key => $gd_image) {
 
 			$ImageWidths[$key]  = imagesx($gd_image);
 			$ImageHeights[$key] = imagesy($gd_image);
-	    	$bpp[$key]          = imageistruecolor($gd_image) ? 32 : 24;
-	    	$totalcolors[$key]  = imagecolorstotal($gd_image);
+			$bpp[$key]          = imageistruecolor($gd_image) ? 32 : 24;
+			$totalcolors[$key]  = imagecolorstotal($gd_image);
 
 			$icXOR[$key] = '';
 			for ($y = $ImageHeights[$key] - 1; $y >= 0; $y--) {
@@ -63,25 +63,25 @@ class phpthumb_ico {
 
 		}
 
-	    $BitmapInfoHeader = [];
-	    foreach ($gd_image_array as $key => $gd_image) {
+		$BitmapInfoHeader = [];
+		foreach ($gd_image_array as $key => $gd_image) {
 			$biSizeImage = $ImageWidths[$key] * $ImageHeights[$key] * ($bpp[$key] / 8);
 
-	    	// BITMAPINFOHEADER - 40 bytes
+			// BITMAPINFOHEADER - 40 bytes
 			$BitmapInfoHeader[$key]  = '';
 			$BitmapInfoHeader[$key] .= "\x28\x00\x00\x00";                              // DWORD  biSize;
 			$BitmapInfoHeader[$key] .= phpthumb_functions::LittleEndian2String($ImageWidths[$key], 4);      // LONG   biWidth;
 			// The biHeight member specifies the combined
 			// height of the XOR and AND masks.
 			$BitmapInfoHeader[$key] .= phpthumb_functions::LittleEndian2String($ImageHeights[$key] * 2, 4); // LONG   biHeight;
-	    	$BitmapInfoHeader[$key] .= "\x01\x00";                                      // WORD   biPlanes;
-	   		$BitmapInfoHeader[$key] .= chr($bpp[$key])."\x00";                          // wBitCount;
+			$BitmapInfoHeader[$key] .= "\x01\x00";                                      // WORD   biPlanes;
+			$BitmapInfoHeader[$key] .= chr($bpp[$key])."\x00";                          // wBitCount;
 			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biCompression;
 			$BitmapInfoHeader[$key] .= phpthumb_functions::LittleEndian2String($biSizeImage, 4);            // DWORD  biSizeImage;
-	    	$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // LONG   biXPelsPerMeter;
-	    	$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // LONG   biYPelsPerMeter;
-	    	$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biClrUsed;
-	    	$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biClrImportant;
+			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // LONG   biXPelsPerMeter;
+			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // LONG   biYPelsPerMeter;
+			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biClrUsed;
+			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biClrImportant;
 		}
 
 
@@ -91,32 +91,32 @@ class phpthumb_ico {
 
 		$dwImageOffset = 6 + (count($gd_image_array) * 16);
 		foreach ($gd_image_array as $key => $gd_image) {
-	    	// ICONDIRENTRY   idEntries[1]; // An entry for each image (idCount of 'em)
+			// ICONDIRENTRY   idEntries[1]; // An entry for each image (idCount of 'em)
 
-	    	$icondata .= chr($ImageWidths[$key]);                     // bWidth;          // Width, in pixels, of the image
-	    	$icondata .= chr($ImageHeights[$key]);                    // bHeight;         // Height, in pixels, of the image
-	    	$icondata .= chr($totalcolors[$key]);                     // bColorCount;     // Number of colors in image (0 if >=8bpp)
-	    	$icondata .= "\x00";                                      // bReserved;       // Reserved ( must be 0)
+			$icondata .= chr($ImageWidths[$key]);                     // bWidth;          // Width, in pixels, of the image
+			$icondata .= chr($ImageHeights[$key]);                    // bHeight;         // Height, in pixels, of the image
+			$icondata .= chr($totalcolors[$key]);                     // bColorCount;     // Number of colors in image (0 if >=8bpp)
+			$icondata .= "\x00";                                      // bReserved;       // Reserved ( must be 0)
 
-	    	$icondata .= "\x01\x00";                                  // wPlanes;         // Color Planes
+			$icondata .= "\x01\x00";                                  // wPlanes;         // Color Planes
 			$icondata .= chr($bpp[$key])."\x00";                      // wBitCount;       // Bits per pixel
 
 			$dwBytesInRes = 40 + strlen($icXOR[$key]) + strlen($icAND[$key]);
 			$icondata .= phpthumb_functions::LittleEndian2String($dwBytesInRes, 4);       // dwBytesInRes;    // How many bytes in this resource?
 
-		    $icondata .= phpthumb_functions::LittleEndian2String($dwImageOffset, 4);      // dwImageOffset;   // Where in the file is this image?
+			$icondata .= phpthumb_functions::LittleEndian2String($dwImageOffset, 4);      // dwImageOffset;   // Where in the file is this image?
 			$dwImageOffset += strlen($BitmapInfoHeader[$key]);
 			$dwImageOffset += strlen($icXOR[$key]);
 			$dwImageOffset += strlen($icAND[$key]);
-	    }
+		}
 
-	    foreach ($gd_image_array as $key => $gd_image) {
+		foreach ($gd_image_array as $key => $gd_image) {
 			$icondata .= $BitmapInfoHeader[$key];
 			$icondata .= $icXOR[$key];
 			$icondata .= $icAND[$key];
-	    }
+		}
 
-	    return $icondata;
+		return $icondata;
 	}
 
 }


### PR DESCRIPTION
further cleanup the original PR (#66)

This covers:

- initialization of variables
- removed (some) superfluous variables
- also removed superfluous params for methods `phpthumb_functions::SafeURLread` and `phpthumb_bmp::LittleEndian2Int`

There is still more cleanup todo (following the [object calisthenics](http://www.slideshare.net/rdohms/object-calisthenicstek13) of early returns, avoiding `else`-statements etc)

Also there's a request of dropping older PHP (<5.5) versions which would remove alot of code too... but thats outside of this PR :)