### PR TITLE
Fix memory limit detected as only a few bytes when lowercase is used

### DIFF
--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -230,9 +230,9 @@ class phpthumb {
 
 		foreach (array(ini_get('memory_limit'), get_cfg_var('memory_limit')) as $php_config_memory_limit) {
 			if (strlen($php_config_memory_limit)) {
-				if (substr($php_config_memory_limit, -1, 1) == 'G') { // PHP memory limit expressed in Gigabytes
+				if (strtoupper(substr($php_config_memory_limit, -1, 1)) == 'G') { // PHP memory limit expressed in Gigabytes
 					$php_config_memory_limit = intval(substr($php_config_memory_limit, 0, -1)) * 1073741824;
-				} elseif (substr($php_config_memory_limit, -1, 1) == 'M') { // PHP memory limit expressed in Megabytes
+				} elseif (strtoupper(substr($php_config_memory_limit, -1, 1)) == 'M') { // PHP memory limit expressed in Megabytes
 					$php_config_memory_limit = intval(substr($php_config_memory_limit, 0, -1)) * 1048576;
 				}
 				$this->php_memory_limit = max($this->php_memory_limit, $php_config_memory_limit);


### PR DESCRIPTION
e.g. memory_limit value of
- 256m fails (detected as 256 bytes) causing $this->config_max_source_pixels to be just 51 pixels
- 256M is detected correctly

I had a few users reporting thumbnailing failing strangely, and i have managed to track it down to this

The side effect of this is that  SourceImageIsTooLarge()  returns false, because of the very low value of $this->config_max_source_pixels

I think this can be merged on just code review