### PR TITLE
AllowOutputEnlargement & Zoom-crop

### DIFF
--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -1734,7 +1734,11 @@ class phpthumb {
 							$sideY = phpthumb_functions::nonempty_min(                     $this->source_height, $hAll, round($wAll / $zcAR));
 
 							$thumbnailH = round(max($sideY, ($sideY * $zcAR) / $imAR));
-							$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement(($IMuseExplicitImageOutputDimensions ? $thumbnailH : '').'x'.$thumbnailH);
+							if($this->aoe == 1) {
+								$commandline .= ' -'.$IMresizeParameter.' "'.$wAll.'x'.$hAll.'^"';
+							} else {
+								$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement(($IMuseExplicitImageOutputDimensions ? $thumbnailH : '').'x'.$thumbnailH);
+							}
 
 							switch (strtoupper($this->zc)) {
 								case 'T':


### PR DESCRIPTION
Hi there,

I have an image (978x275) that is smaller than the desired size (1600x600) and I want it to be enlarged and cropped around the center.
If I try `w=1600,h=600,zc=C,aoe=1` the output remains at 978x275.
If I try `w=1600,h=600,zc=C` the output remains at 978x275.
If I try `w=1600,h=600,aoe=1` the output enlarges to 1600x450, which is not enough as it should be 2134x600.

With `convert input.jpg -resize '1600x600^' -gravity Center -crop 1600x600+0+0 +repage output.jpg` it works. Note the Circumflex (^) behind the resize setting and the quotation marks.

If I try now `w=1600,h=600,zc=C,aoe=1` the output enlarges and zoom-crops to the center and is exactly 1600x600.

I don't know if that is the right place for this bugfix, but it works as expected. :-)
