### PR TITLE
spelling fixes

### DIFF
--- a/demo/phpThumb.demo.check.php
+++ b/demo/phpThumb.demo.check.php
@@ -379,7 +379,7 @@ if (!$server_software) {
 	echo 'darkgreen';
 }
 echo ';">'.$server_software.'</th>';
-echo '<td>Apache v1.x has the fewest compatability problems. IIS has numerous annoyances. Apache v2.x is broken when lookup up <i>/~user/filename.jpg</i> style relative filenames using <i>apache_lookup_uri()</i>.</td></tr>';
+echo '<td>Apache v1.x has the fewest compatibility problems. IIS has numerous annoyances. Apache v2.x is broken when lookup up <i>/~user/filename.jpg</i> style relative filenames using <i>apache_lookup_uri()</i>.</td></tr>';
 
 
 echo '<tr><th>curl_version:</th><th colspan="2" style="background-color: ';

--- a/docs/phpthumb.readme.txt
+++ b/docs/phpthumb.readme.txt
@@ -119,7 +119,7 @@ For example:
 <image> must be the last item. Dimensions must be the second-
 last item. As many key/value pairs for parameters can be
 passed before those last two items, with each pair joined by
-equals ("=") and seperated by semicolon (";")
+equals ("=") and separated by semicolon (";")
 
 
 ==============================================
@@ -230,11 +230,11 @@ fltr = filter system. Call as an array as follows:
        - "brit" (Brightness) [ex: &fltr[]=brit|<value>]
          where <value> is the amount +/- to adjust brightness
          (range -255 to 255)
-         Availble in PHP5 with bundled GD only.
+         Available in PHP5 with bundled GD only.
        - "cont" (Constrast) [ex: &fltr[]=cont|<value>]
          where <value> is the amount +/- to adjust contrast
          (range -255 to 255)
-         Availble in PHP5 with bundled GD only.
+         Available in PHP5 with bundled GD only.
        - "gam" (Gamma Correction) [ex: &fltr[]=gam|<value>]
          where <value> can be a number 0.01 to 10 (default 1.0)
          Must be >0 (zero gives no effect). There is no max,
@@ -278,13 +278,13 @@ fltr = filter system. Call as an array as follows:
        - "blur" (Blur) [ex: &fltr[]=blur|<radius>]
          where (0 < <radius> < 25) (default = 1)
        - "gblr" (Gaussian Blur) [ex: &fltr[]=gblr]
-         Availble in PHP5 with bundled GD only.
+         Available in PHP5 with bundled GD only.
        - "sblr" (Selective Blur) [ex: &fltr[]=gblr]
-         Availble in PHP5 with bundled GD only.
+         Available in PHP5 with bundled GD only.
        - "smth" (Smooth) [ex: &fltr[]=smth|<value>]
          where <value> is the weighting value for the matrix
          (range -10 to 10, default 6)
-         Availble in PHP5 with bundled GD only.
+         Available in PHP5 with bundled GD only.
        - "lvl" (Levels)
          [ex: &fltr[]=lvl|<channel>|<method>|<threshold>
          where <channel> can be one of 'r', 'g', 'b', 'a' (for
@@ -319,7 +319,7 @@ fltr = filter system. Call as an array as follows:
          Where <b> is the color band(s) to display, from back
          to front (one or more of "rgba*" for Red Green Blue
          Alpha and Grayscale respectively);
-         <c> is a semicolon-seperated list of hex colors to
+         <c> is a semicolon-separated list of hex colors to
          use for each graph band (defaults to FF0000, 00FF00,
          0000FF, 999999, FFFFFF respectively);
          <w> and <h> are the width and height of the overlaid
@@ -465,7 +465,7 @@ fltr = filter system. Call as an array as follows:
          to stretch (if 1) or resize proportionately (0, default)
          <x> and <y> will be interpreted as percentage of current
          output image size if values are (0 < X < 1)
-         NOTE: do NOT use this filter unless absolutely neccesary.
+         NOTE: do NOT use this filter unless absolutely necessary.
          It is only provided for cases where other filters need to
          have absolute positioning based on source image and the
          resultant image should be resized after other filters are
@@ -482,13 +482,13 @@ fltr = filter system. Call as an array as follows:
          the two thresholds will be partially transparent.
 md5s = MD5 hash of the source image -- if this parameter is
        passed with the hash of the source image then the
-       source image is not checked for existance or
+       source image is not checked for existence or
        modification and the cached file is used (if
        available). If 'md5s' is passed an empty string then
        phpThumb.php dies and outputs the correct MD5 hash
        value.  This parameter is the single-file equivalent
        of 'cache_source_filemtime_ignore_*' configuration
-       paramters
+       parameters
  xto = EXIF Thumbnail Only - set to only extract EXIF
        thumbnail and not do any additional processing
   ra = Rotate by Angle: angle of rotation in degrees

--- a/phpThumb.php
+++ b/phpThumb.php
@@ -621,7 +621,7 @@ if ($phpThumb->rawImageData) {
 		$phpThumb->src = $cleanedupurl;
 		unset($cleanedupurl);
 		if ($rawImageData = phpthumb_functions::SafeURLread($phpThumb->src, $error, $phpThumb->config_http_fopen_timeout, $phpThumb->config_http_follow_redirect)) {
-			$phpThumb->DebugMessage('SafeURLread('.$phpThumb->src.') succeeded'.($error ? ' with messsages: "'.$error.'"' : ''), __FILE__, __LINE__);
+			$phpThumb->DebugMessage('SafeURLread('.$phpThumb->src.') succeeded'.($error ? ' with messages: "'.$error.'"' : ''), __FILE__, __LINE__);
 			$phpThumb->DebugMessage('Setting source data from URL "'.$phpThumb->src.'"', __FILE__, __LINE__);
 			$phpThumb->setSourceData($rawImageData, urlencode($phpThumb->src));
 		} else {

--- a/phpthumb.bmp.php
+++ b/phpthumb.bmp.php
@@ -378,7 +378,7 @@ class phpthumb_bmp {
 		}
 
 		if ($ExtractData) {
-			$RowByteLength = ceil(($thisfile_bmp_header_raw['width'] * ($thisfile_bmp_header_raw['bits_per_pixel'] / 8)) / 4) * 4; // round up to nearest DWORD boundry
+			$RowByteLength = ceil(($thisfile_bmp_header_raw['width'] * ($thisfile_bmp_header_raw['bits_per_pixel'] / 8)) / 4) * 4; // round up to nearest DWORD boundary
 
 			$BMPpixelData = substr($BMPdata, $thisfile_bmp_header_raw['data_offset'], $thisfile_bmp_header_raw['height'] * $RowByteLength);
 			$overalloffset = $thisfile_bmp_header_raw['data_offset'] + ($thisfile_bmp_header_raw['height'] * $RowByteLength);

--- a/phpthumb.filters.php
+++ b/phpthumb.filters.php
@@ -603,7 +603,7 @@ class phpthumb_filters {
 
 		$range_scale = (($range_max == $range_min) ? 1 : (255 / ($range_max - $range_min)));
 		if (($range_min == 0) && ($range_max == 255)) {
-			// no adjustment neccesary - don't waste CPU time!
+			// no adjustment necessary - don't waste CPU time!
 			return true;
 		}
 
@@ -1271,7 +1271,7 @@ class phpthumb_filters {
 						case 'L':
 						case 'TL':
 						case 'BL':
-							// no change neccesary
+							// no change necessary
 							break;
 
 						case 'C':

--- a/phpthumb.unsharp.php
+++ b/phpthumb.unsharp.php
@@ -37,7 +37,7 @@ difference in colour values that is allowed between the original and the mask. I
 this means that low-contrast areas of the picture are left unrendered whereas edges
 are treated normally. This is good for pictures of e.g. skin or blue skies.
 
-Any suggenstions for improvement of the algorithm, expecially regarding the speed
+Any suggenstions for improvement of the algorithm, especially regarding the speed
 and the roundoff errors in the Gaussian blur process, are welcome.
 */
 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.