### PR TITLE
fix fsockopen http status text

### DIFF
--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -663,7 +663,7 @@ class phpthumb_functions {
 				} else {
 					$data_body .= $line;
 				}
-				if (preg_match('#^HTTP/[\\.\d]+ ([\d]+) (.+)$#i', rtrim($line), $matches)) {
+				if (preg_match('#^HTTP\/[\\.\d]+ ([\d]+)\s*(.+)?$#i', rtrim($line), $matches)) {
 					list( , $errno, $errstr) = $matches;
 					$errno = (int) $errno;
 				} elseif (preg_match('#^Location: (.*)$#i', rtrim($line), $matches)) {

--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -663,7 +663,7 @@ class phpthumb_functions {
 				} else {
 					$data_body .= $line;
 				}
-				if (preg_match('#^HTTP\/[\\.\d]+ ([\d]+)\s*(.+)?$#i', rtrim($line), $matches)) {
+				if (preg_match('#^HTTP/[\\.\d]+ ([\d]+)\s*(.+)?$#i', rtrim($line), $matches)) {
 					list( , $errno, $errstr) = $matches;
 					$errno = (int) $errno;
 				} elseif (preg_match('#^Location: (.*)$#i', rtrim($line), $matches)) {


### PR DESCRIPTION
Some webserver only send a status code in the header. phpthumb treats this as an error even if the status code is 200. Example: https://es2.devgs.de/client/assets/kein_bild.png

The regex makes the status text optional.