### PR TITLE
fix default bg color when converting image with transparency to a non…

### DIFF
--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -208,7 +208,7 @@ class phpthumb {
 	public $tempFilesToDelete = array();
 	public $cache_filename    = null;
 
-	public $AlphaCapableFormats = array( 'png', 'ico', 'gif');
+	public $AlphaCapableFormats = array( 'png', 'ico', 'gif', 'webp');
 	public $is_alpha = false;
 
 	public $iswindows        = null;
@@ -1747,7 +1747,7 @@ class phpthumb {
 					if (!preg_match('#('.implode('|', $this->AlphaCapableFormats).')#i', $outputFormat)) {
 						// not a transparency-capable format
 						$commandline .= ' -background '.phpthumb_functions::escapeshellarg_replacement('#'.($this->bg ? $this->bg : 'FFFFFF'));
-						if ($getimagesize[2] == IMAGETYPE_GIF) {
+						if (!stristr($commandline, ' -flatten')) {
 							$commandline .= ' -flatten';
 						}
 					} else {


### PR DESCRIPTION
fix default bg color when converting image with transparency to a non-alpha-capable format (e.g. JPEG)

### before 
`phpThumb.php?src=home.png&w=410&h=410`

![before](https://user-images.githubusercontent.com/20860485/52891153-b64c8d80-3191-11e9-9fa3-732bdeee9c6b.jpg)
### after 
`phpThumb.php?src=home.png&w=410&h=410`
![after](https://user-images.githubusercontent.com/20860485/52891156-c06e8c00-3191-11e9-8a3a-5ab541cc7ab4.jpg)
