### PR TITLE
PHP parse_url return user/pass instead of username/password

### DIFF
--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -725,7 +725,7 @@ class phpthumb_functions {
 		}
 
 		$cleaned_url  = $parsed_url['scheme'].'://';
-		$cleaned_url .= ($parsed_url['username'] ? $parsed_url['username'].($parsed_url['password'] ? ':'.$parsed_url['password'] : '').'@' : '');
+		$cleaned_url .= ($parsed_url['user'] ? $parsed_url['user'].($parsed_url['pass'] ? ':'.$parsed_url['pass'] : '').'@' : '');
 		$cleaned_url .= $parsed_url['host'];
 		$cleaned_url .= (($parsed_url['port'] && ($parsed_url['port'] != self::URLschemeDefaultPort($parsed_url['scheme']))) ? ':'.$parsed_url['port'] : '');
 		$cleaned_url .= '/'.implode('/', $CleanPathElements);


### PR DESCRIPTION
parse_url() returns an array containing "user"and "pass" keys. The keys are already correctly handled in ParseURLbetter().
Depending on the errorlevel, trying to get username/password causes warnings (on PHP 7.3) to be prepended to the output, which leads to invalid data.

https://www.php.net/manual/de/function.parse-url.php