### PR TITLE
Curly brace syntax on array elements has been removed in PHP 8.0

### DIFF
--- a/phpthumb.gif.php
+++ b/phpthumb.gif.php
@@ -1093,9 +1093,9 @@ class CGIF
 		for ($i = 0; $i < $NumColorsInPal; $i++) {
 			$ThisImageColor[$i] = imagecolorallocate(
 									$PlottingIMG,
-									ord($pal{($i * 3) + 0}),
-									ord($pal{($i * 3) + 1}),
-									ord($pal{($i * 3) + 2}));
+									ord($pal[($i * 3) + 0]),
+									ord($pal[($i * 3) + 1]),
+									ord($pal[($i * 3) + 2]));
 		}
 
 		// PREPARE BITMAP BITS


### PR DESCRIPTION
PHP_CodeSniffer returned this error: Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4 and removed in PHP 8.0.