### PR TITLE
IMAGETYPE_AVIF not included in ImageTypeToMIMEtype()

### DIFF
--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -173,7 +173,7 @@ class phpthumb_functions {
 
 
 	public static function ImageTypeToMIMEtype($imagetype) {
-		if (function_exists('image_type_to_mime_type') && ($imagetype >= 1) && ($imagetype <= 18)) {
+		if (function_exists('image_type_to_mime_type') && ($imagetype >= 1) && ($imagetype <= 19)) {
 			// PHP v4.3.0+
 			return image_type_to_mime_type($imagetype);
 		}
@@ -196,6 +196,7 @@ class phpthumb_functions {
 			16 => 'image/xbm',                     // IMAGETYPE_XBM
 			17 => 'image/x-icon',                  // IMAGETYPE_ICO
 			18 => 'image/webp',                    // IMAGETYPE_WEBP
+            19 => 'image/avif',                    // IMAGETYPE_AVIF
 
 			'gif'  => 'image/gif',                 // IMAGETYPE_GIF
 			'jpg'  => 'image/jpeg',                // IMAGETYPE_JPEG
@@ -204,6 +205,7 @@ class phpthumb_functions {
 			'bmp'  => 'image/bmp',                 // IMAGETYPE_BMP
 			'ico'  => 'image/x-icon',              // IMAGETYPE_ICO
 			'webp' => 'image/webp',                // IMAGETYPE_WEBP
+            'avif' => 'image/avif',                // IMAGETYPE_AVIF
 		);
 
 		return (isset($image_type_to_mime_type[$imagetype]) ? $image_type_to_mime_type[$imagetype] : false);

--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -196,7 +196,7 @@ class phpthumb_functions {
 			16 => 'image/xbm',                     // IMAGETYPE_XBM
 			17 => 'image/x-icon',                  // IMAGETYPE_ICO
 			18 => 'image/webp',                    // IMAGETYPE_WEBP
-            19 => 'image/avif',                    // IMAGETYPE_AVIF
+			19 => 'image/avif',                    // IMAGETYPE_AVIF
 
 			'gif'  => 'image/gif',                 // IMAGETYPE_GIF
 			'jpg'  => 'image/jpeg',                // IMAGETYPE_JPEG
@@ -205,7 +205,7 @@ class phpthumb_functions {
 			'bmp'  => 'image/bmp',                 // IMAGETYPE_BMP
 			'ico'  => 'image/x-icon',              // IMAGETYPE_ICO
 			'webp' => 'image/webp',                // IMAGETYPE_WEBP
-            'avif' => 'image/avif',                // IMAGETYPE_AVIF
+			'avif' => 'image/avif',                // IMAGETYPE_AVIF
 		);
 
 		return (isset($image_type_to_mime_type[$imagetype]) ? $image_type_to_mime_type[$imagetype] : false);


### PR DESCRIPTION
Adds AVIF format in function ImageTypeToMIMEtype() to be complete