### PR TITLE
Removes deprecation warnings at least on PHP 8.2

### DIFF
--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -238,7 +238,7 @@ class phpthumb_functions {
 
 	public static function ImageColorAllocateAlphaSafe(&$gdimg_hexcolorallocate, $R, $G, $B, $alpha=false) {
 		if (self::version_compare_replacement(PHP_VERSION, '4.3.2', '>=') && ($alpha !== false)) {
-			return imagecolorallocatealpha($gdimg_hexcolorallocate, $R, $G, $B, (int) $alpha);
+			return imagecolorallocatealpha($gdimg_hexcolorallocate, round($R), round($G), round($B), (int) $alpha);
 		} else {
 			return imagecolorallocate($gdimg_hexcolorallocate, $R, $G, $B);
 		}


### PR DESCRIPTION
Removes deprecation warnings like:
Deprecated: Implicit conversion from float 90.6 to int loses precision in /app/hc.lv/inc/phpThumb/phpthumb.functions.php on line 242