### PR TITLE
Fixes warnings at least for PHP 8.2

### DIFF
--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -1986,8 +1986,8 @@ if (false) {
 										}
 									}
 									list($nw, $nh) = phpthumb_functions::TranslateWHbyAngle($this->w, $this->h, $this->ra);
-									$nw = ((round($nw) != 0) ? round($nw) : '');
-									$nh = ((round($nh) != 0) ? round($nh) : '');
+									$nw = ((isset($nw) && round($nw) != 0) ? round($nw) : '');
+									$nh = ((isset($nh) && round($nh) != 0) ? round($nh) : '');
 									$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement($nw.'x'.$nh);
 								}
 


### PR DESCRIPTION
Fixes warnings at least for PHP 8.2 if w or h param is not specified.