### PR TITLE
fix for php 8.2 - deprecated null parameter to explode()

### DIFF
--- a/phpthumb.functions.php
+++ b/phpthumb.functions.php
@@ -706,7 +706,7 @@ class phpthumb_functions {
 			return $url;
 		}
 		$parsed_url = self::ParseURLbetter($url);
-		$pathelements = explode('/', $parsed_url['path']);
+		$pathelements = explode('/', (string)$parsed_url['path']);
 		$CleanPathElements = array();
 		$TranslationMatrix = array(' '=>'%20');
 		foreach ($pathelements as $key => $pathelement) {
@@ -718,7 +718,7 @@ class phpthumb_functions {
 			}
 		}
 
-		$queries = explode($queryseperator, $parsed_url['query']);
+		$queries = explode($queryseperator, (string)$parsed_url['query']);
 		$CleanQueries = array();
 		foreach ($queries as $key => $query) {
 			@list($param, $value) = explode('=', $query);


### PR DESCRIPTION
null parameter to second paremeter of explode throws warning in php 8.2: "Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated". Now fixed.