### PR TITLE
Update phpthumb.class.php

### DIFF
--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -1492,7 +1492,8 @@ class phpthumb {
 				if (($cachedwhichconvertstring = @file_get_contents($IMwhichConvertCacheFilename)) !== false) {
 					$WhichConvert = $cachedwhichconvertstring;
 				} else {
-					$WhichConvert = trim(phpthumb_functions::SafeExec('which convert'));
+					$execResult = phpthumb_functions::SafeExec('which convert');
+					$WhichConvert = $execResult !== null ? trim($execResult) : null;
 					@file_put_contents($IMwhichConvertCacheFilename, $WhichConvert);
 					@chmod($IMwhichConvertCacheFilename, $this->getParameter('config_file_create_mask'));
 				}


### PR DESCRIPTION
with PHP 8.2, Fixing Deprecated warning:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in phpthumb.class.php on line 1495