### PR TITLE
Fix TypeError for PHP 7.4

### DIFF
--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -314,7 +314,7 @@ class phpthumb {
 		$this->purgeTempFiles();
 	}
 
-	public function __set(string $name, mixed $value): void {
+	public function __set(string $name, $value): void {
 	}
 
 	// public:


### PR DESCRIPTION
The PR #216 creates a fatal error in PHP 7.4, because the pseudo type `mixed` was only added in PHP 8.

```
Fatal error: Uncaught TypeError: Argument 2 passed to phpthumb::__set() must be an instance of mixed, bool given
```