### PR TITLE
Avoid Arbitrary File Deletion abuse via Object Injection

### DIFF
--- a/phpthumb.class.php
+++ b/phpthumb.class.php
@@ -320,7 +320,7 @@ class phpthumb {
 	// public:
 	public function purgeTempFiles() {
 		foreach ($this->tempFilesToDelete as $tempFileToDelete) {
-			if (file_exists($tempFileToDelete)) {
+			if ((strpos(basename($tempFileToDelete), 'pThumb') === 0) && file_exists($tempFileToDelete)) {
 				$this->DebugMessage('Deleting temp file "'.$tempFileToDelete.'"', __FILE__, __LINE__);
 				@unlink($tempFileToDelete);
 			}


### PR DESCRIPTION
Try to check temp file is really a pThumb temp file before deleting it, to avoid abuse via Object Injection.